### PR TITLE
adios_comm: close the engine in dtor

### DIFF
--- a/redev_comm.h
+++ b/redev_comm.h
@@ -135,7 +135,8 @@ class AdiosComm : public Communicator<T> {
     ~AdiosComm() {
       eng.Close();
     }
-    /// don't allow copy/move/assign
+    /// We are explicitly not allowing copy/move constructor/assignment as we don't
+    /// know if the ADIOS2 Engine and IO objects can be safely copied/moved.
     AdiosComm(const AdiosComm& other) = delete;
     AdiosComm(AdiosComm&& other) = delete;
     AdiosComm& operator=(const AdiosComm& other) = delete;

--- a/redev_comm.h
+++ b/redev_comm.h
@@ -129,6 +129,18 @@ class AdiosComm : public Communicator<T> {
       : comm(comm_), recvRanks(recvRanks_), eng(eng_), io(io_), name(name_), verbose(0) {
         inMsg.knownSizes = false;
     }
+    
+    //rule of 5 en.cppreference.com/w/cpp/language/rule_of_three
+    /// destructor to close the engine
+    ~AdiosComm() {
+      eng.Close();
+    }
+    /// don't allow copy/move/assign
+    AdiosComm(const AdiosComm& other) = delete;
+    AdiosComm(AdiosComm&& other) = delete;
+    AdiosComm& operator=(const AdiosComm& other) = delete;
+    AdiosComm& operator=(AdiosComm&& other) = delete;
+
     void SetOutMessageLayout(LOs& dest_, LOs& offsets_) {
       REDEV_FUNCTION_TIMER;
       outMsg = OutMessageLayout{dest_, offsets_};


### PR DESCRIPTION
The ADIOS2 Engine objects need to have `Close()` called by the user (see my mistake here https://github.com/ornladios/ADIOS2/issues/3269#issuecomment-1175317420).

This PR adds a destructor for the `AdiosComm` class to close the engine.  Following the rule of 5, I explicitly marked the copy/move assignment/constructors as `delete` as I currently only want users to call `CreateAdiosComm(...)` and not manipulate individual comm objects.

@jacobmerson Do you see a problem here?  Is there a reason to allow `AdiosComm` object copy/move?