### PR TITLE
Convert CommPair-> Bidirectional CommPair

### DIFF
--- a/docsDoxySphinx/api/cpp_doxygen_sphinx.rst
+++ b/docsDoxySphinx/api/cpp_doxygen_sphinx.rst
@@ -62,10 +62,10 @@ Types
 .. doxygenclass:: redev::Redev
    :project: Redev
 
-`CommPair`
+`BidirectionalComm`
 ----------
 
-.. doxygenstruct:: redev::CommPair
+.. doxygenstruct:: redev::BidirectionalComm
    :project: Redev
 
 `Communicator`

--- a/redev.h
+++ b/redev.h
@@ -303,18 +303,33 @@ class RCBPtn : public Partition {
 };
 
 /**
- * A CommPair is a pair of communication objects using ADIOS2.
- * s2c is the object for server-to-client communications.
- * c2s is the object for client-to-server communications.
- * The 'server' is the set of processes with the rendezvous partition.
- * A 'client' is a set of processes that queries the rendezvous partition.
+ * A BidirectionalComm is a communicator that can send and receive data
+ * If you are on a client rank sending sends data to the server and receiving
+ * retrieves data from server.
+ * If you are on a server rank sending sends data to the client and receiving
+ * retrieves data from client.
  */
-template <class T>
-struct CommPair {
-  /// server-to-client
-  redev::AdiosComm<T> s2c;
-  /// client-to-server
-  redev::AdiosComm<T> c2s;
+template <class T> struct BidirectionalComm {
+  BidirectionalComm(std::unique_ptr<Communicator<T>> sender_,
+                    std::unique_ptr<Communicator<T>> receiver_)
+      : sender(std::move(sender_)), receiver(std::move(receiver_)) {
+    REDEV_ALWAYS_ASSERT(sender != nullptr);
+    REDEV_ALWAYS_ASSERT(receiver != nullptr);
+  }
+  void SetOutMessageLayout(LOs &dest, LOs &offsets) {
+    sender->SetOutMessageLayout(dest, offsets);
+  }
+  InMessageLayout GetInMessageLayout() {
+    return receiver->GetInMessageLayout();
+  }
+
+public:
+  void Send(T *msgs) { sender->Send(msgs); }
+  std::vector<T> Recv() { return receiver->Recv(); }
+
+private:
+  std::unique_ptr<Communicator<T>> sender;
+  std::unique_ptr<Communicator<T>> receiver;
 };
 
 enum class ProcessType {
@@ -343,15 +358,16 @@ class Redev {
      */
     Redev(MPI_Comm comm, Partition& ptn, ProcessType processType = ProcessType::Client, bool noClients= false);
     /**
-     * Create a ADIOS2-based CommPair between the server and one client
-     * @param[in] name name for the communication channel, each CommPair must have a unique name
+     * Create a ADIOS2-based BidirectionalComm between the server and one client
+     * @param[in] name name for the communication channel, each BidirectionalComm must have a unique name
      * @param[in] params list of ADIOS2 parameters controlling IO and Engine creation, see
      * https://adios2.readthedocs.io/en/latest/engines/engines.html for the list
      * of applicable parameters for the SST and BP4 engines
      * @param[in] transportType by default the BP4 Engine is used, other transport
      * types are available in the TransportType enum
      */
-    template<typename T> CommPair<T> CreateAdiosClient(std::string_view name, adios2::Params params,
+    template<typename T>
+    BidirectionalComm<T> CreateAdiosClient(std::string_view name, adios2::Params params,
                                   TransportType transportType = TransportType::BP4);
     ProcessType GetProcessType() const;
 
@@ -377,7 +393,7 @@ class Redev {
 };
 
 template<typename T>
-CommPair<T> Redev::CreateAdiosClient(std::string_view name, adios2::Params params,
+BidirectionalComm<T> Redev::CreateAdiosClient(std::string_view name, adios2::Params params,
                                      TransportType transportType) {
   auto s2cName = std::string(name)+"_s2c";
   auto c2sName = std::string(name)+"_c2s";
@@ -420,9 +436,14 @@ CommPair<T> Redev::CreateAdiosClient(std::string_view name, adios2::Params param
   Setup(s2cIO,s2cEngine);
   const auto serverRanks = GetServerCommSize(s2cIO,s2cEngine);
   const auto clientRanks = GetClientCommSize(c2sIO,c2sEngine);
-  return CommPair<T>{
-    AdiosComm<T>(comm, clientRanks, s2cEngine, s2cIO, std::string(name)+"_s2c"),
-    AdiosComm<T>(comm, serverRanks, c2sEngine, c2sIO, std::string(name)+"_c2s")};
+  auto s2c = std::make_unique<AdiosComm<T>>(comm, clientRanks, s2cEngine, s2cIO, std::string(name)+"_s2c");
+  auto c2s = std::make_unique<AdiosComm<T>>(comm, serverRanks, c2sEngine, c2sIO, std::string(name)+"_c2s");
+  switch (processType) {
+  case ProcessType::Client:
+    return {std::move(c2s), std::move(s2c)};
+  case ProcessType::Server:
+    return {std::move(s2c), std::move(c2s)};
+  }
 }
 
 }

--- a/redev.h
+++ b/redev.h
@@ -309,7 +309,9 @@ class RCBPtn : public Partition {
  * If you are on a server rank sending sends data to the client and receiving
  * retrieves data from client.
  */
-template <class T> struct BidirectionalComm {
+template <class T>
+class BidirectionalComm {
+public:
   BidirectionalComm(std::unique_ptr<Communicator<T>> sender_,
                     std::unique_ptr<Communicator<T>> receiver_)
       : sender(std::move(sender_)), receiver(std::move(receiver_)) {
@@ -323,7 +325,6 @@ template <class T> struct BidirectionalComm {
     return receiver->GetInMessageLayout();
   }
 
-public:
   void Send(T *msgs) { sender->Send(msgs); }
   std::vector<T> Recv() { return receiver->Recv(); }
 

--- a/redev_comm.h
+++ b/redev_comm.h
@@ -35,38 +35,6 @@ void Broadcast(T* data, int count, int root, MPI_Comm comm) {
 }
 
 /**
- * The Communicator class provides an abstract interface for sending and
- * receiving messages to/from the client and server.
- */
-template<typename T>
-class Communicator {
-  public:
-    /**
-     * Set the arrangement of data in the messages array so that its segments,
-     * defined by the offsets array, are sent to the correct destination ranks,
-     * defined by the dest array.
-     * @param[in] dest array of integers specifying the destination rank for a
-     * portion of the msgs array
-     * @param[in] offsets array of length |dest|+1 defining the segment of the
-     * msgs array (passed to the Send function) being sent to each destination rank.
-     * the segment [ msgs[offsets[i]] : msgs[offsets[i+1]] } is sent to rank dest[i]
-     */
-    virtual void SetOutMessageLayout(LOs& dest, LOs& offsets) = 0;
-    /**
-     * Send the array.
-     * @param[in] msgs array of data to be sent according to the layout specified
-     *            with SetOutMessageLayout
-     */
-    virtual void Send(T* msgs) = 0;
-    /**
-     * Receive an array. Use AdiosComm's GetInMessageLayout to retreive
-     * an instance of the InMessageLayout struct containing the layout of
-     * the received array.
-     */
-    virtual std::vector<T> Recv() = 0;
-};
-
-/**
  * The InMessageLayout struct contains the arrays defining the arrangement of
  * data in the array returned by Communicator::Recv.
  */
@@ -101,6 +69,43 @@ struct InMessageLayout {
    */
   size_t count;
 };
+
+/**
+ * The Communicator class provides an abstract interface for sending and
+ * receiving messages to/from the client and server.
+ * TODO: Split Communicator into Send/Recieve Communicators, bidirectional constructed by composition and can perform both send and receive
+ */
+template<typename T>
+class Communicator {
+  public:
+    /**
+     * Set the arrangement of data in the messages array so that its segments,
+     * defined by the offsets array, are sent to the correct destination ranks,
+     * defined by the dest array.
+     * @param[in] dest array of integers specifying the destination rank for a
+     * portion of the msgs array
+     * @param[in] offsets array of length |dest|+1 defining the segment of the
+     * msgs array (passed to the Send function) being sent to each destination rank.
+     * the segment [ msgs[offsets[i]] : msgs[offsets[i+1]] } is sent to rank dest[i]
+     */
+    virtual void SetOutMessageLayout(LOs& dest, LOs& offsets) = 0;
+    /**
+     * Send the array.
+     * @param[in] msgs array of data to be sent according to the layout specified
+     *            with SetOutMessageLayout
+     */
+    virtual void Send(T* msgs) = 0;
+    /**
+     * Receive an array. Use AdiosComm's GetInMessageLayout to retreive
+     * an instance of the InMessageLayout struct containing the layout of
+     * the received array.
+     */
+    virtual std::vector<T> Recv() = 0;
+
+    virtual InMessageLayout GetInMessageLayout() = 0;
+    virtual ~Communicator() = default;
+};
+
 
 /**
  * The AdiosComm class implements the Communicator interface to support sending

--- a/test_pingpong.cpp
+++ b/test_pingpong.cpp
@@ -34,14 +34,14 @@ int main(int argc, char** argv) {
       if(iter==0) {
         redev::LOs dest = redev::LOs{0};
         redev::LOs offsets = redev::LOs{0,1};
-        commPair.c2s.SetOutMessageLayout(dest, offsets);
+        commPair.SetOutMessageLayout(dest, offsets);
       }
       redev::LOs msgs = redev::LOs(1,42);
-      commPair.c2s.Send(msgs.data());
+      commPair.Send(msgs.data());
     } else {
-      auto msgs = commPair.c2s.Recv();
+      auto msgs = commPair.Recv();
       if(iter == 0) {
-        auto inMsg = commPair.c2s.GetInMessageLayout();
+        auto inMsg = commPair.GetInMessageLayout();
         REDEV_ALWAYS_ASSERT(inMsg.offset == redev::GOs({0,1}));
         REDEV_ALWAYS_ASSERT(inMsg.srcRanks == redev::GOs({0}));
         REDEV_ALWAYS_ASSERT(inMsg.start == 0);
@@ -54,14 +54,14 @@ int main(int argc, char** argv) {
       if(iter==0) {
         redev::LOs dest = redev::LOs{0};
         redev::LOs offsets = redev::LOs{0,1};
-        commPair.s2c.SetOutMessageLayout(dest, offsets);
+        commPair.SetOutMessageLayout(dest, offsets);
       }
       redev::LOs msgs = redev::LOs(1,1337);
-      commPair.s2c.Send(msgs.data());
+      commPair.Send(msgs.data());
     } else {
-      auto msgs = commPair.s2c.Recv();
+      auto msgs = commPair.Recv();
       if(iter==0) {
-        auto inMsg = commPair.s2c.GetInMessageLayout();
+        auto inMsg = commPair.GetInMessageLayout();
         REDEV_ALWAYS_ASSERT(inMsg.offset == redev::GOs({0,1}));
         REDEV_ALWAYS_ASSERT(inMsg.srcRanks == redev::GOs({0}));
         REDEV_ALWAYS_ASSERT(inMsg.start == 0);

--- a/test_send.cpp
+++ b/test_send.cpp
@@ -54,8 +54,8 @@ int main(int argc, char** argv) {
       offsets = redev::LOs{0,4,5,7,11};
       msgs = redev::LOs(11,2);
     }
-    commPair.c2s.SetOutMessageLayout(dest, offsets);
-    commPair.c2s.Send(msgs.data());
+    commPair.SetOutMessageLayout(dest, offsets);
+    commPair.Send(msgs.data());
   }
   }
   MPI_Finalize();

--- a/test_sendOneToTwo.cpp
+++ b/test_sendOneToTwo.cpp
@@ -43,8 +43,8 @@ int main(int argc, char** argv) {
     dest = redev::LOs{0,1};
     offsets = redev::LOs{0,2,6};
     redev::LOs msgs = {0,0,1,1,1,1};
-    commPair.c2s.SetOutMessageLayout(dest, offsets);
-    commPair.c2s.Send(msgs.data());
+    commPair.SetOutMessageLayout(dest, offsets);
+    commPair.Send(msgs.data());
   }
   }
   MPI_Finalize();

--- a/test_sendrecv.cpp
+++ b/test_sendrecv.cpp
@@ -63,11 +63,11 @@ int main(int argc, char** argv) {
       offsets = redev::LOs{0,4,5,7,11};
       msgs = redev::LOs(11,2);
     }
-    commPair.c2s.SetOutMessageLayout(dest, offsets);
-    commPair.c2s.Send(msgs.data());
+    commPair.SetOutMessageLayout(dest, offsets);
+    commPair.Send(msgs.data());
   } else {
-    auto msgVec = commPair.c2s.Recv();
-    auto inMsg = commPair.c2s.GetInMessageLayout();
+    auto msgVec = commPair.Recv();
+    auto inMsg = commPair.GetInMessageLayout();
     REDEV_ALWAYS_ASSERT(inMsg.offset == redev::GOs({0,7,11,21,27}));
     REDEV_ALWAYS_ASSERT(inMsg.srcRanks == redev::GOs({0,0,0,0,2,0,4,0,3,3,8,2}));
     if(rank == 0) {

--- a/util_benchsr.cpp
+++ b/util_benchsr.cpp
@@ -71,8 +71,8 @@ void sendRecvRdv(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const int r
     constructCsrOffsets(mbpr,rdvRanks,offsets);
     redev::LOs msgs(mbpr,rank);
     auto start = std::chrono::steady_clock::now();
-    commPair.c2s.SetOutMessageLayout(dest, offsets);
-    commPair.c2s.Send(msgs.data());
+    commPair.SetOutMessageLayout(dest, offsets);
+    commPair.Send(msgs.data());
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
     double min, max, avg;
@@ -82,7 +82,7 @@ void sendRecvRdv(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const int r
     if(!rank) printTime(str, min, max, avg);
   } else {
     auto start = std::chrono::steady_clock::now();
-    commPair.c2s.Recv();
+    commPair.Recv();
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
     double min, max, avg;

--- a/util_benchsrLarge.cpp
+++ b/util_benchsrLarge.cpp
@@ -91,11 +91,11 @@ void sendRecvRdvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
         redev::LOs dest = {destRank};
         redev::LOs offsets;
         constructCsrOffsetsMapped(destRank, mbpr, offsets);
-        commPair.c2s.SetOutMessageLayout(dest, offsets);
+        commPair.SetOutMessageLayout(dest, offsets);
       }
       redev::LOs msgs(mbpr,rank);
       auto start = std::chrono::steady_clock::now();
-      commPair.c2s.Send(msgs.data());
+      commPair.Send(msgs.data());
       auto end = std::chrono::steady_clock::now();
       std::chrono::duration<double> elapsed_seconds = end-start;
       double min, max, avg;
@@ -105,7 +105,7 @@ void sendRecvRdvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
       if(!rank) printTime(str, min, max, avg);
     } else {
       auto start = std::chrono::steady_clock::now();
-      auto msgs = commPair.c2s.Recv();
+      auto msgs = commPair.Recv();
       auto end = std::chrono::steady_clock::now();
       std::chrono::duration<double> elapsed_seconds = end-start;
       double min, max, avg;
@@ -150,11 +150,11 @@ void sendRecvRdvFanOut(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
         std::iota(dest.begin(),dest.end(),0);
         redev::LOs offsets(mbpr);
         constructCsrOffsetsFanOut(mbpr,rdvRanks,offsets);
-        commPair.c2s.SetOutMessageLayout(dest, offsets);
+        commPair.SetOutMessageLayout(dest, offsets);
       }
       redev::LOs msgs(mbpr,rank);
       auto start = std::chrono::steady_clock::now();
-      commPair.c2s.Send(msgs.data());
+      commPair.Send(msgs.data());
       auto end = std::chrono::steady_clock::now();
       std::chrono::duration<double> elapsed_seconds = end-start;
       double min, max, avg;
@@ -164,7 +164,7 @@ void sendRecvRdvFanOut(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
       if(!rank) printTime(str, min, max, avg);
     } else {
       auto start = std::chrono::steady_clock::now();
-      commPair.c2s.Recv();
+      commPair.Recv();
       auto end = std::chrono::steady_clock::now();
       std::chrono::duration<double> elapsed_seconds = end-start;
       double min, max, avg;


### PR DESCRIPTION
A new class BidirectionalComm replaces CommPair. Unlike the communicator
which it is only valid to send or recieve, the BidirectionalComm uses
composition to construct a communicator that is valid for sending and
receiving.