### PR TITLE
CreateAdiosClient: silence GCC 10 warning

### DIFF
--- a/redev.h
+++ b/redev.h
@@ -440,11 +440,13 @@ BidirectionalComm<T> Redev::CreateAdiosClient(std::string_view name, adios2::Par
   auto s2c = std::make_unique<AdiosComm<T>>(comm, clientRanks, s2cEngine, s2cIO, std::string(name)+"_s2c");
   auto c2s = std::make_unique<AdiosComm<T>>(comm, serverRanks, c2sEngine, c2sIO, std::string(name)+"_c2s");
   switch (processType) {
-  case ProcessType::Client:
-    return {std::move(c2s), std::move(s2c)};
-  case ProcessType::Server:
-    return {std::move(s2c), std::move(c2s)};
+    case ProcessType::Client:
+      return {std::move(c2s), std::move(s2c)};
+    case ProcessType::Server:
+      return {std::move(s2c), std::move(c2s)};
   }
+  REDEV_ALWAYS_ASSERT(false);  //we should never get here
+  return {nullptr, nullptr}; //silence compiler warning
 }
 
 }


### PR DESCRIPTION
This is an attempt to silence the following GCC10 compiler warning.  Is there a cleaner solution?

```
Consolidate compiler generated dependencies of target test_pingpong
[ 78%] Building CXX object CMakeFiles/test_pingpong.dir/test_pingpong.cpp.o
In file included from /space/cwsmith/wdmCpl/redev/test_pingpong.cpp:3:
/space/cwsmith/wdmCpl/redev/redev.h: In member function 'redev::BidirectionalComm<T> redev::Redev::CreateAdiosClient(std::string_view, adios2::Params, redev::TransportType) [with T = int]':
/space/cwsmith/wdmCpl/redev/redev.h:449:1: warning: control reaches end of non-void function [-Wreturn-type]
  449 | }
      | ^
[ 80%] Linking CXX executable test_pingpong
```