### PR TITLE
redev v3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.0...3.21.0)
 
-project(redev VERSION 2.0.0 LANGUAGES C CXX) #C is required to find MPI_C
+project(redev VERSION 3.0.0 LANGUAGES C CXX) #C is required to find MPI_C
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
The change from CommPair to Bidirectional CommPair in https://github.com/SCOREC/redev/commit/5ab51d1bdf88359a2df0a201b6b9d0be4679d1bc was not backwards compatible (by design) so, following https://semver.org/, we need to increase the major version.