### PR TITLE
second attempt to fix the circular dependency between redev and redev_comm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.0...3.21.0)
 
-project(redev VERSION 3.0.0 LANGUAGES C CXX) #C is required to find MPI_C
+project(redev VERSION 3.0.1 LANGUAGES C CXX) #C is required to find MPI_C
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/redev_comm.h
+++ b/redev_comm.h
@@ -1,5 +1,6 @@
 #pragma once
-#include "redev.h"
+#include "redev_types.h"
+#include "redev_assert.h"
 #include "redev_profile.h"
 #include "redev_assert.h"
 #include <numeric> // accumulate, exclusive_scan

--- a/test_pingpong.cpp
+++ b/test_pingpong.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <cstdlib>
 #include "redev.h"
-#include "redev_comm.h"
 
 int main(int argc, char** argv) {
   int rank, nproc;

--- a/test_send.cpp
+++ b/test_send.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <cstdlib>
 #include "redev.h"
-#include "redev_comm.h"
 
 //If the name of the variable being sent ("foo"), the communication
 //pattern, or data being sent is changed then also update the cmake

--- a/test_sendOneToTwo.cpp
+++ b/test_sendOneToTwo.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <cstdlib>
 #include "redev.h"
-#include "redev_comm.h"
 
 //If the name of the variable being sent ("foo"), the communication
 //pattern, or data being sent is changed then also update the cmake

--- a/test_sendrecv.cpp
+++ b/test_sendrecv.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <cstdlib>
 #include "redev.h"
-#include "redev_comm.h"
 
 /**
  * \page test_sendrecv

--- a/test_twoClients.cpp
+++ b/test_twoClients.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <cstdlib>
 #include "redev.h"
-#include "redev_comm.h"
 
 /**
  * \page test_twoclients

--- a/util_benchsr.cpp
+++ b/util_benchsr.cpp
@@ -4,7 +4,6 @@
 #include <chrono> //steady_clock, duration
 #include <thread> //this_thread
 #include "redev.h"
-#include "redev_comm.h"
 #include "util_support.h"
 
 #define MILLION 1024*1024

--- a/util_benchsrLarge.cpp
+++ b/util_benchsrLarge.cpp
@@ -4,7 +4,6 @@
 #include <chrono> //steady_clock, duration
 #include <thread> //this_thread
 #include "redev.h"
-#include "redev_comm.h"
 #include "util_support.h"
 
 #define MILLION 1024*1024


### PR DESCRIPTION
This should be a cleaner fix than #21 for the circular dependency between redev.h and redev_comm.h discussed in #16.