### PR TITLE
Redev takes partition object as unique_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ if(BUILD_TESTING)
     TIMEOUT ${test_timeout}
     NAME1 rdv PROCS1 1 EXE1 ./test_initPtnObjOwnership ARGS1 1
     NAME2 app PROCS2 1 EXE2 ./test_initPtnObjOwnership ARGS2 0)
-  set_property(TEST test_initPtnObjOwnership PROPERTY WILL_FAIL TRUE)
   add_exe(test_setup_rcbPtn test_setup_rcbPtn.cpp)
   dual_mpi_test(TESTNAME test_setup_rcbPtn_1p
     TIMEOUT ${test_timeout}

--- a/redev.cpp
+++ b/redev.cpp
@@ -322,8 +322,8 @@ namespace redev {
     }
   }
 
-  Redev::Redev(MPI_Comm comm, Partition&ptn, ProcessType processType_, bool noClients)
-    : comm(comm), adios(comm), ptn(ptn), processType(processType_), noClients(noClients) {
+  Redev::Redev(MPI_Comm comm, std::unique_ptr<Partition> ptn, ProcessType processType_, bool noClients)
+    : comm(comm), adios(comm), partition(std::move(ptn)), processType(processType_), noClients(noClients) {
     REDEV_FUNCTION_TIMER;
     int isInitialized = 0;
     MPI_Initialized(&isInitialized);
@@ -339,12 +339,12 @@ namespace redev {
     //rendezvous app rank 0 writes partition info and other apps read
     if(!rank) {
       if(processType==ProcessType::Server)
-        ptn.Write(s2cEngine,s2cIO);
+        partition->Write(s2cEngine,s2cIO);
       else
-        ptn.Read(s2cEngine,s2cIO);
+        partition->Read(s2cEngine,s2cIO);
     }
     s2cEngine.EndStep();
-    ptn.Broadcast(comm);
+    partition->Broadcast(comm);
   }
 
   /*

--- a/redev_comm.h
+++ b/redev_comm.h
@@ -131,7 +131,7 @@ class AdiosComm : public Communicator<T> {
      * @param[in] name_ unique name among AdiosComm objects
      */
     AdiosComm(MPI_Comm comm_, int recvRanks_, adios2::Engine& eng_, adios2::IO& io_, std::string name_)
-      : comm(comm_), recvRanks(recvRanks_), eng(eng_), io(io_), name(name_), verbose(0) {
+      : comm(comm_), recvRanks(recvRanks_), eng(eng_), io(io_), name(std::move(name_)), verbose(0) {
         inMsg.knownSizes = false;
     }
     
@@ -191,8 +191,8 @@ class AdiosComm : public Communicator<T> {
       assert(rdvVar);
       const auto srcRanksName = name+"_srcRanks";
       //The source rank offsets array is the same on each process ('regular').
-      adios2::Dims srShape{static_cast<size_t>(commSz*recvRanks)};
-      adios2::Dims srStart{static_cast<size_t>(recvRanks*rank)};
+      adios2::Dims srShape{static_cast<size_t>(commSz)*recvRanks};
+      adios2::Dims srStart{static_cast<size_t>(recvRanks)*rank};
       adios2::Dims srCount{static_cast<size_t>(recvRanks)};
       checkStep(eng.BeginStep());
 

--- a/test_1d.cpp
+++ b/test_1d.cpp
@@ -10,10 +10,7 @@ int main(int argc, char** argv) {
   adios2::ADIOS adios(MPI_COMM_WORLD);
   adios2::IO io = adios.DeclareIO("Write");
   std::string engineName = "BP4";
-  if (!engineName.empty())
-  {
-    io.SetEngine(engineName);
-  }
+  io.SetEngine(engineName);
 
   adios2::Engine engine = io.Open("foo.bp", adios2::Mode::Write);
 
@@ -39,13 +36,13 @@ int main(int argc, char** argv) {
 
   engine.BeginStep();
 
-  start = adios2::Dims{static_cast<size_t>(mpiRank*Nx)};
+  start = adios2::Dims{static_cast<size_t>(mpiRank)*Nx};
   count = adios2::Dims{static_cast<size_t>(1)};
   var_i32.SetSelection({start,count});
   int x = 42;
   engine.Put(var_i32, &x);
 
-  start = adios2::Dims{static_cast<size_t>(mpiRank*Nx+1)};
+  start = adios2::Dims{static_cast<size_t>(mpiRank)*Nx+1};
   var_i32.SetSelection({start,count});
   int y = 43;
   engine.Put(var_i32, &y);

--- a/test_init.cpp
+++ b/test_init.cpp
@@ -6,10 +6,10 @@ int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nproc);
-  redev::RCBPtn ptn;
+  auto ptn = std::make_unique<redev::RCBPtn>();
   auto isRendezvous=true;
   auto noClients=true;
-  redev::Redev(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRendezvous),noClients);
+  redev::Redev(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRendezvous),noClients);
   MPI_Finalize();
   return 0;
 }

--- a/test_initPtnObjOwnership.cpp
+++ b/test_initPtnObjOwnership.cpp
@@ -4,8 +4,8 @@
 const std::string timeout="8";
 
 auto makeRedev(int dim, redev::LOs& ranks, redev::Reals& cuts, bool isRendezvous) {
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  return redev::Redev(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRendezvous));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  return redev::Redev(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRendezvous));
 }
 
 void client() {

--- a/test_pingpong.cpp
+++ b/test_pingpong.cpp
@@ -23,8 +23,8 @@ int main(int argc, char** argv) {
   const auto dim = 1;
   auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
   auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_profile.cpp
+++ b/test_profile.cpp
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
     redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     std::array<redev::Real,3> pt{0.6, 0.0, 0.0};
     const auto* partition = dynamic_cast<const redev::RCBPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition != nullptr);
     const int numCalls = 10;
     for(auto i=0; i<numCalls; i++)
       partition->GetRank(pt);

--- a/test_profile.cpp
+++ b/test_profile.cpp
@@ -16,12 +16,13 @@ int main(int argc, char** argv) {
     const auto dim = 1;
     std::vector<redev::LO> ranks = {0,1,2,3};
     std::vector<redev::Real> cuts = {0,0.5,0.25,0.75};
-    auto ptn = redev::RCBPtn(dim,ranks,cuts);
-    redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv),noParticipant);
+    auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     std::array<redev::Real,3> pt{0.6, 0.0, 0.0};
+    const auto* partition = dynamic_cast<const redev::RCBPtn*>(rdv.GetPartition());
     const int numCalls = 10;
     for(auto i=0; i<numCalls; i++)
-      ptn.GetRank(pt);
+      partition->GetRank(pt);
 
     auto prof = redev::Profiling::GetInstance();
     prof->Write(std::cout);

--- a/test_query.cpp
+++ b/test_query.cpp
@@ -14,25 +14,29 @@ int main(int argc, char** argv) {
   { //classPtn
     std::vector<redev::LO> ranks = {0,1,2,3};
     const redev::ClassPtn::ModelEntVec modelEnts {{0,0},{1,0},{2,0},{2,1}};
-    auto ptn = redev::ClassPtn(MPI_COMM_WORLD,ranks,modelEnts);
-    redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv),noParticipant);
+    auto ptn = std::make_unique<redev::ClassPtn>(MPI_COMM_WORLD,ranks,modelEnts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     using ModelEnt = redev::ClassPtn::ModelEnt;
-    REDEV_ALWAYS_ASSERT(0 == ptn.GetRank(ModelEnt({0,0})) );
-    REDEV_ALWAYS_ASSERT(1 == ptn.GetRank(ModelEnt({1,0})) );
-    REDEV_ALWAYS_ASSERT(2 == ptn.GetRank(ModelEnt({2,0})) );
-    REDEV_ALWAYS_ASSERT(3 == ptn.GetRank(ModelEnt({2,1})) );
+    const auto* partition = dynamic_cast<const redev::ClassPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition != nullptr);
+    REDEV_ALWAYS_ASSERT(0 == partition->GetRank(ModelEnt({0,0})) );
+    REDEV_ALWAYS_ASSERT(1 == partition->GetRank(ModelEnt({1,0})) );
+    REDEV_ALWAYS_ASSERT(2 == partition->GetRank(ModelEnt({2,0})) );
+    REDEV_ALWAYS_ASSERT(3 == partition->GetRank(ModelEnt({2,1})) );
   }
   { //1D RCB
     const auto dim = 1;
     std::vector<redev::LO> ranks = {0,1,2,3};
     std::vector<redev::Real> cuts = {0,0.5,0.25,0.75};
-    auto ptn = redev::RCBPtn(dim,ranks,cuts);
-    redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv),noParticipant);
+    auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     std::array<redev::Real,3> pt{0.6, 0.0, 0.0};
-    pt[0] = 0.6;   REDEV_ALWAYS_ASSERT(2 == ptn.GetRank(pt));
-    pt[0] = 0.01;  REDEV_ALWAYS_ASSERT(0 == ptn.GetRank(pt));
-    pt[0] = 0.5;   REDEV_ALWAYS_ASSERT(2 == ptn.GetRank(pt));
-    pt[0] = 0.751; REDEV_ALWAYS_ASSERT(3 == ptn.GetRank(pt));
+    const auto* partition = dynamic_cast<const redev::RCBPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition != nullptr);
+    pt[0] = 0.6;   REDEV_ALWAYS_ASSERT(2 == partition->GetRank(pt));
+    pt[0] = 0.01;  REDEV_ALWAYS_ASSERT(0 == partition->GetRank(pt));
+    pt[0] = 0.5;   REDEV_ALWAYS_ASSERT(2 == partition->GetRank(pt));
+    pt[0] = 0.751; REDEV_ALWAYS_ASSERT(3 == partition->GetRank(pt));
   }
   { //2D RCB
     const auto dim = 2;
@@ -48,30 +52,34 @@ int main(int argc, char** argv) {
      *
      *       0.0  0.5  1.0
      */
-    auto ptn = redev::RCBPtn(dim,ranks,cuts);
-    redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv),noParticipant);
+    auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     std::array<redev::Real,3> pt{0.1, 0.7, 0.0};
-    pt[0] = 0.1, pt[1] = 0.7; REDEV_ALWAYS_ASSERT(0 == ptn.GetRank(pt));
-    pt[0] = 0.1; pt[1] = 0.8; REDEV_ALWAYS_ASSERT(1 == ptn.GetRank(pt));
-    pt[0] = 0.5; pt[1] = 0.0; REDEV_ALWAYS_ASSERT(2 == ptn.GetRank(pt));
-    pt[0] = 0.7; pt[1] = 0.9; REDEV_ALWAYS_ASSERT(3 == ptn.GetRank(pt));
+    const auto* partition = dynamic_cast<const redev::RCBPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition != nullptr);
+    pt[0] = 0.1, pt[1] = 0.7; REDEV_ALWAYS_ASSERT(0 == partition->GetRank(pt));
+    pt[0] = 0.1; pt[1] = 0.8; REDEV_ALWAYS_ASSERT(1 == partition->GetRank(pt));
+    pt[0] = 0.5; pt[1] = 0.0; REDEV_ALWAYS_ASSERT(2 == partition->GetRank(pt));
+    pt[0] = 0.7; pt[1] = 0.9; REDEV_ALWAYS_ASSERT(3 == partition->GetRank(pt));
   }
   { //3D RCB
     const auto dim = 3;
     std::vector<redev::LO> ranks(8);
     std::iota(ranks.begin(),ranks.end(),0);
     std::vector<redev::Real> cuts = {0,/*x*/0.5,/*y*/0.75,0.25,/*z*/0.1,0.4,0.8,0.3};
-    auto ptn = redev::RCBPtn(dim,ranks,cuts);
-    redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv),noParticipant);
+    auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv),noParticipant);
     using Point = std::array<redev::Real,3>;
-    { Point pt{0.1, 0.7, 0.01}; REDEV_ALWAYS_ASSERT(0 == ptn.GetRank(pt)); }
-    { Point pt{0.1, 0.7, 0.1};  REDEV_ALWAYS_ASSERT(1 == ptn.GetRank(pt)); }
-    { Point pt{0.1, 0.8, 0.1};  REDEV_ALWAYS_ASSERT(2 == ptn.GetRank(pt)); }
-    { Point pt{0.1, 0.8, 0.8};  REDEV_ALWAYS_ASSERT(3 == ptn.GetRank(pt)); }
-    { Point pt{0.6, 0.1, 0.01}; REDEV_ALWAYS_ASSERT(4 == ptn.GetRank(pt)); }
-    { Point pt{0.6, 0.1, 0.9};  REDEV_ALWAYS_ASSERT(5 == ptn.GetRank(pt)); }
-    { Point pt{0.6, 0.8, 0.0};  REDEV_ALWAYS_ASSERT(6 == ptn.GetRank(pt)); }
-    { Point pt{0.6, 0.8, 0.3};  REDEV_ALWAYS_ASSERT(7 == ptn.GetRank(pt)); }
+    const auto* partition = dynamic_cast<const redev::RCBPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition != nullptr);
+    { Point pt{0.1, 0.7, 0.01}; REDEV_ALWAYS_ASSERT(0 == partition->GetRank(pt)); }
+    { Point pt{0.1, 0.7, 0.1};  REDEV_ALWAYS_ASSERT(1 == partition->GetRank(pt)); }
+    { Point pt{0.1, 0.8, 0.1};  REDEV_ALWAYS_ASSERT(2 == partition->GetRank(pt)); }
+    { Point pt{0.1, 0.8, 0.8};  REDEV_ALWAYS_ASSERT(3 == partition->GetRank(pt)); }
+    { Point pt{0.6, 0.1, 0.01}; REDEV_ALWAYS_ASSERT(4 == partition->GetRank(pt)); }
+    { Point pt{0.6, 0.1, 0.9};  REDEV_ALWAYS_ASSERT(5 == partition->GetRank(pt)); }
+    { Point pt{0.6, 0.8, 0.0};  REDEV_ALWAYS_ASSERT(6 == partition->GetRank(pt)); }
+    { Point pt{0.6, 0.8, 0.3};  REDEV_ALWAYS_ASSERT(7 == partition->GetRank(pt)); }
   }
 
   MPI_Finalize();

--- a/test_send.cpp
+++ b/test_send.cpp
@@ -31,8 +31,8 @@ int main(int argc, char** argv) {
   const auto dim = 2;
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_sendOneToTwo.cpp
+++ b/test_sendOneToTwo.cpp
@@ -31,8 +31,8 @@ int main(int argc, char** argv) {
   const auto dim = 2;
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_sendrecv.cpp
+++ b/test_sendrecv.cpp
@@ -40,8 +40,8 @@ int main(int argc, char** argv) {
   const auto dim = 2;
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_setup_classPtn.cpp
+++ b/test_setup_classPtn.cpp
@@ -18,10 +18,10 @@ void classPtnTest(int rank, bool isRdv) {
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>("foo",params,static_cast<redev::TransportType>(isSST));
   if(!isRdv) {
-    const auto* partition = dynamic_cast<const redev::ClassPtn*>(rdv.GetPartition());
-    REDEV_ALWAYS_ASSERT(partition != nullptr);
-    auto p_ranks = partition->GetRanks();
-    auto p_modelEnts = partition->GetModelEnts();
+    const auto* partition_ptr = dynamic_cast<const redev::ClassPtn*>(rdv.GetPartition());
+    REDEV_ALWAYS_ASSERT(partition_ptr != nullptr);
+    auto p_ranks = partition_ptr->GetRanks();
+    auto p_modelEnts = partition_ptr->GetModelEnts();
     REDEV_ALWAYS_ASSERT(p_ranks.size() == 4);
     REDEV_ALWAYS_ASSERT(p_modelEnts.size() == 4);
     EntToRank e2r;

--- a/test_twoClients.cpp
+++ b/test_twoClients.cpp
@@ -235,8 +235,8 @@ int main(int argc, char** argv) {
   const auto dim = 1;
   auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
   auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "6"}};
   if(!isRdv) {
     client(rdv,clientId,params,isSST);

--- a/util_benchsr.cpp
+++ b/util_benchsr.cpp
@@ -120,8 +120,8 @@ void sendRecvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const in
   std::stringstream ss;
   ss << mbpr << " B " << name;
   if(!isRdv) { //sender
-    adios2::Dims shape{static_cast<size_t>(mbpr*nproc)};
-    adios2::Dims start{static_cast<size_t>(mbpr*rank)};
+    adios2::Dims shape{static_cast<size_t>(mbpr)*nproc};
+    adios2::Dims start{static_cast<size_t>(mbpr)*rank};
     adios2::Dims count{static_cast<size_t>(mbpr)};
     auto var = io.DefineVariable<redev::LO>(name, shape, start, count);
     assert(var);

--- a/util_benchsr.cpp
+++ b/util_benchsr.cpp
@@ -55,8 +55,8 @@ void sendRecvRdv(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const int r
   auto ranks = redev::LOs(rdvRanks);
   //the cuts won't be used since getRank(...) won't be called
   auto cuts = redev::Reals(rdvRanks);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   std::stringstream ss;
   ss << mbpr << " B rdv ";
@@ -103,8 +103,8 @@ void sendRecvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const in
   const auto dim = 2;
   auto ranks = redev::LOs(rdvRanks);
   auto cuts = redev::Reals(rdvRanks);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   //get adios objs
   std::string name = "mapped";
   adios2::ADIOS adios(mpiComm);

--- a/util_benchsrLarge.cpp
+++ b/util_benchsrLarge.cpp
@@ -75,8 +75,8 @@ void sendRecvRdvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
   auto ranks = redev::LOs(rdvRanks);
   //the cuts won't be used since getRank(...) won't be called
   auto cuts = redev::Reals(rdvRanks);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "rendezvous";
   std::stringstream ss;
   ss << mbpr << " B rdvMapped ";
@@ -134,8 +134,8 @@ void sendRecvRdvFanOut(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
   auto ranks = redev::LOs(rdvRanks);
   //the cuts won't be used since getRank(...) won't be called
   auto cuts = redev::Reals(rdvRanks);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "rendezvous";
   std::stringstream ss;
   ss << mbpr << " B rdvFanOut ";
@@ -191,8 +191,8 @@ void sendRecvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
   const auto dim = 2;
   auto ranks = redev::LOs(rdvRanks);
   auto cuts = redev::Reals(rdvRanks);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  auto ptn = std::make_unique<redev::RCBPtn>(dim,ranks,cuts);
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   //get adios objs
   std::string name = "mapped";
   adios2::ADIOS adios(mpiComm);


### PR DESCRIPTION
This solves the object ownership issue that is created by storing a reference to the partition in the redev class.

The ownership issue came up while working on the coupler so, I implemented the fix.

closes #8

@cwsmith if you don't like that the user has to create a `unique_ptr` the alternative is to still pass in a reference of the partition to `Redev` and then copy it into a a unique_ptr internal to `Redev`.