### PR TITLE
Use variant type to describe the Partition object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15.0...3.21.0)
 
-project(redev VERSION 3.0.1 LANGUAGES C CXX) #C is required to find MPI_C
+project(redev VERSION 4.0.0 LANGUAGES C CXX) #C is required to find MPI_C
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(REDEV_HEADERS
   redev_time.h
   redev_assert.h
   redev_strings.h
+  redev_variant_tools.h
   )
 
 set(REDEV_SOURCES
@@ -130,7 +131,6 @@ if(BUILD_TESTING)
     TIMEOUT ${test_timeout}
     NAME1 rdv PROCS1 1 EXE1 ./test_initPtnObjOwnership ARGS1 1
     NAME2 app PROCS2 1 EXE2 ./test_initPtnObjOwnership ARGS2 0)
-  set_property(TEST test_initPtnObjOwnership PROPERTY WILL_FAIL TRUE)
   add_exe(test_setup_rcbPtn test_setup_rcbPtn.cpp)
   dual_mpi_test(TESTNAME test_setup_rcbPtn_1p
     TIMEOUT ${test_timeout}

--- a/docsDoxySphinx/api/cpp_doxygen_sphinx.rst
+++ b/docsDoxySphinx/api/cpp_doxygen_sphinx.rst
@@ -37,10 +37,10 @@ Types
    :project: Redev
 
 
-`Partition`
+`PartitionInterface`
 -----------
 
-.. doxygenclass:: redev::Partition
+.. doxygenclass:: redev::PartitionInterface
    :project: Redev
 
 `ClassPtn`

--- a/redev.h
+++ b/redev.h
@@ -324,6 +324,7 @@ using Partition = std::variant<ClassPtn,RCBPtn>;
 template <class T>
 class BidirectionalComm {
 public:
+  BidirectionalComm() = default;
   BidirectionalComm(std::unique_ptr<Communicator<T>> sender_,
                     std::unique_ptr<Communicator<T>> receiver_)
       : sender(std::move(sender_)), receiver(std::move(receiver_)) {

--- a/redev_variant_tools.h
+++ b/redev_variant_tools.h
@@ -1,10 +1,10 @@
 #ifndef REDEV__REDEV_VARIANT_TOOLS_H
 #define REDEV__REDEV_VARIANT_TOOLS_H
-namespace wdmcpl {
+namespace redev {
 // see visit entry on cppreference
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 // explicit deduction guide (not needed as of C++20)
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-} // namespace wdmcpl
+} // namespace redev
 
 #endif // REDEV__REDEV_VARIANT_TOOLS_H

--- a/redev_variant_tools.h
+++ b/redev_variant_tools.h
@@ -1,0 +1,10 @@
+#ifndef REDEV__REDEV_VARIANT_TOOLS_H
+#define REDEV__REDEV_VARIANT_TOOLS_H
+namespace wdmcpl {
+// see visit entry on cppreference
+template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+} // namespace wdmcpl
+
+#endif // REDEV__REDEV_VARIANT_TOOLS_H

--- a/test_pingpong.cpp
+++ b/test_pingpong.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
   auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
   auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_send.cpp
+++ b/test_send.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_sendOneToTwo.cpp
+++ b/test_sendOneToTwo.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_sendrecv.cpp
+++ b/test_sendrecv.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   auto ranks = isRdv ? redev::LOs({0,1,2,3}) : redev::LOs(4);
   auto cuts = isRdv ? redev::Reals({0,0.5,0.75,0.25}) : redev::Reals(4);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>(name,params,redev::TransportType::BP4);

--- a/test_setup_classPtn.cpp
+++ b/test_setup_classPtn.cpp
@@ -12,12 +12,11 @@ void classPtnTest(int rank, bool isRdv) {
     expectedE2R[expectedEnts[i]] = expectedRanks[i];
   auto ranks = isRdv ? expectedRanks : redev::LOs();
   auto ents = isRdv ? expectedEnts : redev::ClassPtn::ModelEntVec();
-  auto partition = redev::ClassPtn(MPI_COMM_WORLD,ranks,ents);
-  redev::Redev rdv(MPI_COMM_WORLD,partition,static_cast<redev::ProcessType>(isRdv));
-  const bool isSST = false;
+  redev::Redev rdv(MPI_COMM_WORLD,redev::ClassPtn(MPI_COMM_WORLD,ranks,ents),static_cast<redev::ProcessType>(isRdv));
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
-  auto commPair = rdv.CreateAdiosClient<redev::LO>("foo",params,static_cast<redev::TransportType>(isSST));
+  auto commPair = rdv.CreateAdiosClient<redev::LO>("foo",params,redev::TransportType::BP4);
   if(!isRdv) {
+    const auto& partition = std::get<redev::ClassPtn>(rdv.GetPartition());
     auto p_ranks = partition.GetRanks();
     auto p_modelEnts = partition.GetModelEnts();
     REDEV_ALWAYS_ASSERT(p_ranks.size() == 4);

--- a/test_setup_rcbPtn.cpp
+++ b/test_setup_rcbPtn.cpp
@@ -9,13 +9,13 @@ void rcbPtnTest(int rank, bool isRdv) {
   auto ranks = isRdv ? expectedRanks : redev::LOs(4);
   auto cuts = isRdv ? expectedCuts : redev::Reals(4);
   const auto dim = 2;
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD, redev::RCBPtn(dim,ranks,cuts),static_cast<redev::ProcessType>(isRdv));
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "2"}};
   auto commPair = rdv.CreateAdiosClient<redev::LO>("foo",params,redev::TransportType::BP4);
   if(!isRdv) {
-    auto ptnRanks = ptn.GetRanks();
-    auto ptnCuts = ptn.GetCuts();
+    const auto& partition = std::get<redev::RCBPtn>(rdv.GetPartition());
+    auto ptnRanks = partition.GetRanks();
+    auto ptnCuts = partition.GetCuts();
     REDEV_ALWAYS_ASSERT(ptnRanks == expectedRanks);
     REDEV_ALWAYS_ASSERT(ptnCuts == expectedCuts);
   }

--- a/test_twoClients.cpp
+++ b/test_twoClients.cpp
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
   auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
   auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "6"}};
   if(!isRdv) {
     client(rdv,clientId,params,isSST);

--- a/util_benchsr.cpp
+++ b/util_benchsr.cpp
@@ -55,7 +55,7 @@ void sendRecvRdv(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const int r
   //the cuts won't be used since getRank(...) won't be called
   auto cuts = redev::Reals(rdvRanks);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "foo";
   std::stringstream ss;
   ss << mbpr << " B rdv ";
@@ -103,7 +103,7 @@ void sendRecvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr, const in
   auto ranks = redev::LOs(rdvRanks);
   auto cuts = redev::Reals(rdvRanks);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   //get adios objs
   std::string name = "mapped";
   adios2::ADIOS adios(mpiComm);

--- a/util_benchsrLarge.cpp
+++ b/util_benchsrLarge.cpp
@@ -75,7 +75,7 @@ void sendRecvRdvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
   //the cuts won't be used since getRank(...) won't be called
   auto cuts = redev::Reals(rdvRanks);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   std::string name = "rendezvous";
   std::stringstream ss;
   ss << mbpr << " B rdvMapped ";
@@ -191,7 +191,7 @@ void sendRecvMapped(MPI_Comm mpiComm, const bool isRdv, const int mbpr,
   auto ranks = redev::LOs(rdvRanks);
   auto cuts = redev::Reals(rdvRanks);
   auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(mpiComm,ptn,static_cast<redev::ProcessType>(isRdv));
+  redev::Redev rdv(mpiComm,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   //get adios objs
   std::string name = "mapped";
   adios2::ADIOS adios(mpiComm);


### PR DESCRIPTION
The partition object owned by RDV needs a different interface for
GetRank() depending on the partition type. This is an attempt to model
those differing interfaces with a variant type. This allows the user
to write a visitor to address the potiential different partitions.

This is an attempt to address the concerns raised in #28 