### PR TITLE
Initialize client Partition type based on server partition

### DIFF
--- a/redev.cpp
+++ b/redev.cpp
@@ -372,7 +372,7 @@ namespace redev {
   /*
    * return the number of processes in the client's MPI communicator
    */
-  redev::LO Redev::GetClientCommSize(adios2::IO& c2sIO, adios2::Engine& c2sEngine) {
+  redev::LO Redev::SendClientCommSizeToServer(adios2::IO& c2sIO, adios2::Engine& c2sEngine) {
     REDEV_FUNCTION_TIMER;
     int commSize;
     MPI_Comm_size(comm, &commSize);
@@ -400,7 +400,7 @@ namespace redev {
   /*
    * return the number of processes in the server's MPI communicator
    */
-  redev::LO Redev::GetServerCommSize(adios2::IO& s2cIO, adios2::Engine& s2cEngine) {
+  redev::LO Redev::SendServerCommSizeToClient(adios2::IO& s2cIO, adios2::Engine& s2cEngine) {
     REDEV_FUNCTION_TIMER;
     int commSize;
     MPI_Comm_size(comm, &commSize);

--- a/redev.h
+++ b/redev.h
@@ -414,8 +414,8 @@ class Redev {
         std::string s2cName, std::string c2sName,
         adios2::IO& s2cIO, adios2::IO& c2sIO,
         adios2::Engine& s2cEngine, adios2::Engine& c2sEngine);
-    redev::LO GetServerCommSize(adios2::IO& s2cIO, adios2::Engine& s2cEngine);
-    redev::LO GetClientCommSize(adios2::IO& c2sIO, adios2::Engine& c2sEngine);
+    redev::LO SendServerCommSizeToClient(adios2::IO& s2cIO, adios2::Engine& s2cEngine);
+    redev::LO SendClientCommSizeToServer(adios2::IO& c2sIO, adios2::Engine& c2sEngine);
     std::size_t SendPartitionTypeToClient(adios2::IO& s2cIO, adios2::Engine& s2cEngine);
     MPI_Comm comm;
     adios2::ADIOS adios;
@@ -466,8 +466,8 @@ BidirectionalComm<T> Redev::CreateAdiosClient(std::string_view name, adios2::Par
     // an engine type that has been defined in the TransportType enum. (-Werror=switch)
   }
   Setup(s2cIO,s2cEngine);
-  const auto serverRanks = GetServerCommSize(s2cIO,s2cEngine);
-  const auto clientRanks = GetClientCommSize(c2sIO,c2sEngine);
+  const auto serverRanks = SendServerCommSizeToClient(s2cIO, s2cEngine);
+  const auto clientRanks = SendClientCommSizeToServer(c2sIO, c2sEngine);
   auto s2c = std::make_unique<AdiosComm<T>>(comm, clientRanks, s2cEngine, s2cIO, std::string(name)+"_s2c");
   auto c2s = std::make_unique<AdiosComm<T>>(comm, serverRanks, c2sEngine, c2sIO, std::string(name)+"_c2s");
   switch (processType) {

--- a/redev.h
+++ b/redev.h
@@ -364,7 +364,7 @@ enum class TransportType {
 class Redev {
   public:
     /**
-     * Create a Redev object
+     * Create a Redev server
      * @param[in] comm MPI communicator containing the ranks that are part of the server/client
      * @param[in] ptn PartitionInterface object defining the redezvous domain partition (see note below)
      * @param[in] processProcess enum for if the server is a client, server
@@ -373,7 +373,17 @@ class Redev {
      * The server will send the client the needed partition information during
      * the call to CreateAdiosClient.
      */
-    Redev(MPI_Comm comm, Partition ptn, ProcessType processType = ProcessType::Client, bool noClients= false);
+    Redev(MPI_Comm comm, Partition ptn, ProcessType processType = ProcessType::Server, bool noClients= false);
+    /**
+     * Create a Redev client
+     * @param[in] comm MPI communicator containing the ranks that are part of the server/client
+     * @param[in] processProcess enum for if the server is a client, server
+     * @param[in] noClients for testing without any clients present
+     * The client processes should pass in an empty PartitionInterface object.
+     * The server will send the client the needed partition information during
+     * the call to CreateAdiosClient.
+     */
+    Redev(MPI_Comm comm, ProcessType processType = ProcessType::Client, bool noClients= false);
     /**
      * Create a ADIOS2-based BidirectionalComm between the server and one client
      * @param[in] name name for the communication channel, each BidirectionalComm must have a unique name
@@ -406,10 +416,12 @@ class Redev {
         adios2::Engine& s2cEngine, adios2::Engine& c2sEngine);
     redev::LO GetServerCommSize(adios2::IO& s2cIO, adios2::Engine& s2cEngine);
     redev::LO GetClientCommSize(adios2::IO& c2sIO, adios2::Engine& c2sEngine);
+    std::size_t SendPartitionTypeToClient(adios2::IO& s2cIO, adios2::Engine& s2cEngine);
     MPI_Comm comm;
     adios2::ADIOS adios;
     int rank;
     Partition ptn;
+    void ConstructPartitionFromIndex(size_t partition_index);
 };
 
 template<typename T>

--- a/redev_comm.h
+++ b/redev_comm.h
@@ -25,6 +25,13 @@ constexpr MPI_Datatype getMpiType(T) noexcept {
   else if constexpr (std::is_same_v<T, std::complex<double>>) { return MPI_DOUBLE_COMPLEX; }
   else if constexpr (std::is_same_v<T, int64_t>) { return MPI_INT64_T; }
   else if constexpr (std::is_same_v<T, int32_t>) { return MPI_INT32_T; }
+  else if constexpr (std::is_same_v<T, uint64_t>) { return MPI_UINT64_T; }
+  // uint64_t is named "unsigned long long" instead of "unsigned long" however these types have the same size
+  else if constexpr (std::is_same_v<T, unsigned long>) {
+    static_assert(sizeof(unsigned long)==sizeof(uint64_t));
+    return MPI_UINT64_T;
+  }
+  else if constexpr (std::is_same_v<T, uint32_t>) { return MPI_UINT32_T; }
   else{ static_assert(detail::dependent_always_false<T>::value, "type has unkown map to MPI_Type"); return {}; }
 }
 

--- a/test_init.cpp
+++ b/test_init.cpp
@@ -9,7 +9,10 @@ int main(int argc, char** argv) {
   redev::RCBPtn ptn;
   auto isRendezvous=true;
   auto noClients=true;
-  redev::Redev(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRendezvous),noClients);
+  if(static_cast<redev::ProcessType>(isRendezvous) == redev::ProcessType::Server)
+    redev::Redev(MPI_COMM_WORLD,ptn,redev::ProcessType::Server, noClients);
+  else
+    redev::Redev(MPI_COMM_WORLD,redev::ProcessType::Client, noClients);
   MPI_Finalize();
   return 0;
 }

--- a/test_initPtnObjOwnership.cpp
+++ b/test_initPtnObjOwnership.cpp
@@ -4,8 +4,11 @@
 const std::string timeout="8";
 
 auto makeRedev(int dim, redev::LOs& ranks, redev::Reals& cuts, bool isRendezvous) {
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  return redev::Redev(MPI_COMM_WORLD,ptn,static_cast<redev::ProcessType>(isRendezvous));
+  if(static_cast<redev::ProcessType>(isRendezvous) == redev::ProcessType::Server) {
+    auto ptn = redev::RCBPtn(dim,ranks,cuts);
+    return redev::Redev(MPI_COMM_WORLD,ptn);
+  }
+  return redev::Redev(MPI_COMM_WORLD);
 }
 
 void client() {

--- a/test_twoClients.cpp
+++ b/test_twoClients.cpp
@@ -230,16 +230,17 @@ int main(int argc, char** argv) {
   }
   {
   /// [Main]
-  //dummy partition vector data
-  const auto dim = 1;
-  auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
-  auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
-  auto ptn = redev::RCBPtn(dim,ranks,cuts);
-  redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),static_cast<redev::ProcessType>(isRdv));
   adios2::Params params{ {"Streaming", "On"}, {"OpenTimeoutSecs", "6"}};
   if(!isRdv) {
+    redev::Redev rdv(MPI_COMM_WORLD,redev::ProcessType::Client);
     client(rdv,clientId,params,isSST);
   } else {
+    //dummy partition vector data
+    const auto dim = 1;
+    auto ranks = isRdv ? redev::LOs({0}) : redev::LOs(1);
+    auto cuts = isRdv ? redev::Reals({0}) : redev::Reals(1);
+    auto ptn = redev::RCBPtn(dim,ranks,cuts);
+    redev::Redev rdv(MPI_COMM_WORLD,std::move(ptn),redev::ProcessType::Server);
     server(rdv,params,isSST);
   }
   std::cout << "done\n";


### PR DESCRIPTION
The redev client should not need to know what type of partition scheme is being used, or initialize that partition. This modification initializes the client partition type based on the partition type on the server. This is the first step to a safer interface where the client cannot attempt to set a partition.