### PR TITLE
remove clang++ from matrix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++,clang++]
+        compiler: [g++]
         language: ['cpp']
         build_type: [Debug, Release]
     # Permissions needed for codeql analysis 


### PR DESCRIPTION
This is a temporary fix to remove the clang build which causes FindMPI to fail.