### PR TITLE
Fix invalid link and command in docs

### DIFF
--- a/docsDoxySphinx/conf.py
+++ b/docsDoxySphinx/conf.py
@@ -17,7 +17,7 @@ from sphinx.builders.html import StandaloneHTMLBuilder
 import subprocess, os
 
 # Doxygen
-subprocess.call('doxygen Doxyfile', shell=True)
+subprocess.call('doxygen Doxyfile.193', shell=True)
 
 # -- Project information -----------------------------------------------------
 

--- a/docsDoxySphinx/index.rst
+++ b/docsDoxySphinx/index.rst
@@ -16,7 +16,6 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
 
 


### PR DESCRIPTION
Remove the broken page `py-modindex.html` and fix the incorrect Doxyfile command.