### PR TITLE
Added perfstubs location in find_dependency

### DIFF
--- a/config.cmake.in
+++ b/config.cmake.in
@@ -9,5 +9,5 @@ include(CMakeFindDependencyMacro)
 enable_language(C) #required for MPI::MPI_C
 find_dependency(MPI)
 find_dependency(ADIOS2 CONFIG HINTS @ADIOS2_DIR@)
-find_dependency(perfstubs)
+find_dependency(perfstubs CONFIG HINTS @perfstubs_DIR@)
 


### PR DESCRIPTION
It should help with the configuration of upstream projects that use redev by finding the perfstubs location automatically.
